### PR TITLE
chore: bump node version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18738,7 +18738,7 @@ dependencies = [
 
 [[package]]
 name = "xcavate-node"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "color-print",

--- a/docs/ismp-token-gateway/ASSET_REGISTRATION.md
+++ b/docs/ismp-token-gateway/ASSET_REGISTRATION.md
@@ -210,7 +210,7 @@ AssetRegistration {
 
 ```rust
 symbol: "TGBP".as_bytes().to_vec(),  // Max 20 chars
-name: "Token Gateway British Pound".as_bytes().to_vec(),  // Max 20 chars
+name: "Tokenised GBP".as_bytes().to_vec(),  // Max 20 chars
 ```
 
 - Symbol is used to generate the asset ID: `keccak256(symbol)`
@@ -265,7 +265,7 @@ Assets::create(
 Assets::set_metadata(
     RuntimeOrigin::signed(admin),
     1,
-    b"Token Gateway British Pound".to_vec(),
+    b"Tokenised GBP".to_vec(),
     b"TGBP".to_vec(),
     6, // Same as Ethereum (no conversion)
 )?;
@@ -280,7 +280,7 @@ let tgbp_registration = AssetRegistration {
 
     reg: GatewayAssetRegistration {
         symbol: "TGBP".as_bytes().to_vec(),
-        name: "Token Gateway British Pound".as_bytes().to_vec(),
+        name: "Tokenised GBP".as_bytes().to_vec(),
         chains: vec![StateMachine::Evm(1)], // Ethereum mainnet
         minimum_balance: 1,
     },

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -12,7 +12,7 @@ These tests validate that Xcavate can correctly receive and process bridged asse
 4. **Balance Tracking** - Balances accumulate correctly across multiple transfers
 5. **Error Handling** - Invalid messages are rejected (unregistered assets, missing precision configs, etc.)
 
-**Current Test Asset:** TGBP (Token Gateway British Pound) - 6 decimals on both Ethereum and Xcavate
+**Current Test Asset:** TGBP (Tokenised GBP) - 6 decimals on both Ethereum and Xcavate
 
 ## Design Philosophy
 

--- a/integration-tests/src/tests/tgbp_integration_tests.rs
+++ b/integration-tests/src/tests/tgbp_integration_tests.rs
@@ -48,7 +48,7 @@ fn register_tgbp_asset() {
     assert_ok!(Assets::force_set_metadata(
         RuntimeOrigin::root(),
         TGBP_LOCAL_ASSET_ID.into(),
-        b"Token Gateway British Pound".to_vec(),
+        b"Tokenised GBP".to_vec(),
         b"TGBP".to_vec(),
         6,     // 6 decimals (same as on Ethereum)
         false  // is_frozen
@@ -631,7 +631,7 @@ fn invalid_precision_mapping() {
 ///
 /// **Verification Points:**
 /// - Symbol: Should be "TGBP"
-/// - Name: Should be "Token Gateway British Pound" (or similar)
+/// - Name: Should be "Tokenised GBP" (or similar)
 /// - Decimals: Should be 6 (matching Ethereum precision)
 ///
 /// **Why it's important:**

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 publish = false
 repository = { workspace = true }
-version = "1.0.0"
+version = "1.1.0"
 
 [dependencies]
 clap = { workspace = true }


### PR DESCRIPTION
Bump minor node version for the node and fixes some typos.
Mostly to keep things consistent.