### PR TITLE
feat(ismp): reserve assetids

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -23,7 +23,7 @@ cargo test
 ```bash
 cd integration-tests
 npm install
-npm run teleport          # Dry run
+npm run teleport          # Prepare (no transaction)
 npm run verify-registration
 ```
 
@@ -91,7 +91,7 @@ JavaScript scripts for live testnet interaction. See [`src/sepolia/README.md`](s
 
 | Script | Command | Description |
 |--------|---------|-------------|
-| `teleport-erc20.js` | `npm run teleport` | Bridge WETH from Sepolia to Xcavate (dry run) |
+| `teleport-erc20.js` | `npm run teleport` | Prepare WETH bridge from Sepolia to Xcavate |
 | `teleport-erc20.js --execute` | `npm run teleport:execute` | Execute actual bridge transaction |
 | `verify-registration.js` | `npm run verify-registration` | Check if token is registered on TokenGateway |
 | `calculate-asset-id.js` | `npm run calc-asset-id` | Calculate keccak256 asset ID for a symbol |
@@ -103,7 +103,7 @@ JavaScript scripts for live testnet interaction. See [`src/sepolia/README.md`](s
 | TokenGateway | [`0xFcDa26cA021d5535C3059547390E6cCd8De7acA6`](https://sepolia.etherscan.io/address/0xFcDa26cA021d5535C3059547390E6cCd8De7acA6) |
 | IsmpHost | [`0x2EdB74C269948b60ec1000040E104cef0eABaae8`](https://sepolia.etherscan.io/address/0x2EdB74C269948b60ec1000040E104cef0eABaae8) |
 
-### Example: Dry Run
+### Example: Prepare Mode
 ```bash
 $ npm run teleport
 
@@ -114,7 +114,7 @@ Transfer Configuration:
   Token:       WETH (0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14)
   Amount:      0.001 WETH
   Destination: PASEO-4683
-  Mode:        DRY RUN (simulation only)
+  Mode:        PREPARE (no transaction)
 ```
 
 ---
@@ -173,7 +173,7 @@ cargo test --manifest-path integration-tests/Cargo.toml sepolia_testnet_messages
 cd integration-tests
 npm install
 
-# Dry run (no transaction)
+# Prepare (no transaction)
 npm run teleport
 
 # Execute with private key
@@ -185,6 +185,27 @@ npm run verify-registration
 # Calculate asset ID
 npm run calc-asset-id WETH
 ```
+
+### Gas Estimation
+
+Use [Foundry's `cast`](https://book.getfoundry.sh/cast/) to estimate gas costs before executing:
+
+```bash
+# Estimate gas for a teleport call
+cast estimate 0xFcDa26cA021d5535C3059547390E6cCd8De7acA6 \
+  "teleport((uint256,uint256,bytes32,bool,bytes32,bytes,uint64,uint256,bytes))" \
+  "(1000000000000000,0,0x0f8a193ff464434486c0daf7db2a895884365d2bc84ba47a68fcf89c1b14b5b8,false,0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d,0x504153454f2d34363833,3600,0,0x)" \
+  --rpc-url https://ethereum-sepolia-rpc.publicnode.com
+
+# Simulate full transaction (requires private key)
+cast send --simulate 0xFcDa26cA021d5535C3059547390E6cCd8De7acA6 \
+  "teleport((uint256,uint256,bytes32,bool,bytes32,bytes,uint64,uint256,bytes))" \
+  "(1000000000000000,0,0x0f8a193ff464434486c0daf7db2a895884365d2bc84ba47a68fcf89c1b14b5b8,false,0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d,0x504153454f2d34363833,3600,0,0x)" \
+  --private-key $PRIVATE_KEY \
+  --rpc-url https://ethereum-sepolia-rpc.publicnode.com
+```
+
+The tuple fields are: `(amount, relayerFee, assetId, redeem, to, dest, timeout, nativeCost, data)`
 
 ---
 

--- a/integration-tests/src/sepolia/README.md
+++ b/integration-tests/src/sepolia/README.md
@@ -48,11 +48,14 @@ The Asset ID is `keccak256("WETH")` and is used to identify the token on the Tok
 
 **Usage:**
 ```bash
+# From the integration-tests directory
+cd integration-tests
+
 # Dry run - shows what would happen without executing
-node teleport-erc20.js
+npm run teleport
 
 # Execute actual teleport (requires wallet)
-PRIVATE_KEY=0x... node teleport-erc20.js --execute
+PRIVATE_KEY=0x... npm run teleport:execute
 ```
 
 **Default Configuration (WETH):**
@@ -88,7 +91,8 @@ Verifies that WETH (or other token) is properly registered on the TokenGateway c
 
 **Usage:**
 ```bash
-node verify-registration.js
+# From the integration-tests directory
+npm run verify-registration
 ```
 
 **Expected Output:**
@@ -104,12 +108,14 @@ Helper script to calculate the asset ID (keccak256 hash) from a token symbol.
 
 **Usage:**
 ```bash
+# From the integration-tests directory
+
 # Calculate for tGBP
-node calculate-asset-id.js tGBP
+npm run calc-asset-id -- tGBP
 
 # Calculate for any symbol
-node calculate-asset-id.js USDC
-node calculate-asset-id.js WETH
+npm run calc-asset-id -- USDC
+npm run calc-asset-id -- WETH
 ```
 
 ## Network Information

--- a/integration-tests/src/sepolia/README.md
+++ b/integration-tests/src/sepolia/README.md
@@ -51,10 +51,10 @@ The Asset ID is `keccak256("WETH")` and is used to identify the token on the Tok
 # From the integration-tests directory
 cd integration-tests
 
-# Dry run - shows what would happen without executing
+# Prepare - validates and shows parameters without executing
 npm run teleport
 
-# Execute actual teleport (requires wallet)
+# Execute teleport (requires wallet)
 PRIVATE_KEY=0x... npm run teleport:execute
 ```
 

--- a/integration-tests/src/sepolia/teleport-erc20.js
+++ b/integration-tests/src/sepolia/teleport-erc20.js
@@ -10,11 +10,11 @@
  * 3. User must have ETH for gas fees
  *
  * Usage:
- *   # Dry run (shows what would happen, no transaction)
- *   node teleport-erc20.js
+ *   # Prepare (validates and shows parameters, no transaction)
+ *   npm run teleport
  *
- *   # Execute actual teleport (requires PRIVATE_KEY env var)
- *   PRIVATE_KEY=0x... node teleport-erc20.js --execute
+ *   # Execute teleport (requires PRIVATE_KEY env var)
+ *   PRIVATE_KEY=0x... npm run teleport:execute
  */
 
 const { ethers } = require('ethers');
@@ -133,7 +133,7 @@ async function teleportERC20() {
     console.log(`  Recipient:   ${CONFIG.recipient}`);
     console.log(`  Destination: ${CONFIG.destination}`);
     console.log(`  Timeout:     ${CONFIG.timeout} seconds`);
-    console.log(`  Mode:        ${executeMode ? 'EXECUTE (real transaction)' : 'DRY RUN (simulation only)'}`);
+    console.log(`  Mode:        ${executeMode ? 'EXECUTE' : 'PREPARE (no transaction)'}`);
     console.log();
 
     // Connect to RPC
@@ -289,7 +289,7 @@ async function teleportERC20() {
     console.log(`    assetId:    ${teleportParams.assetId}`);
     console.log(`    redeem:     ${teleportParams.redeem}`);
     console.log(`    to:         ${teleportParams.to}`);
-    console.log(`    dest:       ${CONFIG.destination}`);
+    console.log(`    dest:       ${ethers.hexlify(destBytes)}`);
     console.log(`    timeout:    ${teleportParams.timeout}`);
     console.log(`    nativeCost: ${teleportParams.nativeCost}`);
     console.log(`    data:       ${teleportParams.data}`);
@@ -358,12 +358,9 @@ async function teleportERC20() {
         }
     } else {
         console.log('-'.repeat(80));
-        console.log('DRY RUN COMPLETE');
+        console.log('To execute the teleport:');
+        console.log('  PRIVATE_KEY=0x... npm run teleport:execute');
         console.log('-'.repeat(80));
-        console.log();
-        console.log('To execute the actual teleport:');
-        console.log('  PRIVATE_KEY=0x... node teleport-erc20.js --execute');
-        console.log();
     }
 }
 

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,11 +1,11 @@
 #[cfg(all(feature = "std", feature = "metadata-hash"))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.enable_metadata_hash("XCAV", 12)
-		.build()
+    substrate_wasm_builder::WasmBuilder::new()
+        .with_current_project()
+        .export_heap_base()
+        .import_memory()
+        .enable_metadata_hash("XCAV", 12)
+        .build()
 }
 
 #[cfg(all(feature = "std", not(feature = "metadata-hash")))]

--- a/runtime/src/configs/ismp.rs
+++ b/runtime/src/configs/ismp.rs
@@ -9,8 +9,10 @@
 
 use alloc::{boxed::Box, vec::Vec};
 
-use frame_support::{parameter_types, traits::Get};
-use frame_support::traits::fungible::ItemOf;
+use frame_support::{
+    parameter_types,
+    traits::{fungible::ItemOf, Get},
+};
 use frame_system::EnsureRoot;
 use ismp::{host::StateMachine, module::IsmpModule, router::IsmpRouter};
 use sp_runtime::traits::AccountIdConversion;

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -54,7 +54,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: alloc::borrow::Cow::Borrowed("template-parachain"),
     impl_name: alloc::borrow::Cow::Borrowed("template-parachain"),
     authoring_version: 1,
-    spec_version: 8,
+    spec_version: 9,
     impl_version: 0,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 7,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -9,6 +9,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 pub mod apis;
 pub mod configs;
 pub mod constants;
+mod migrations;
 mod types;
 mod weights;
 

--- a/runtime/src/migrations/mod.rs
+++ b/runtime/src/migrations/mod.rs
@@ -1,0 +1,5 @@
+//! Runtime migrations for xcavate-runtime.
+
+pub mod reserved_assets;
+
+pub use reserved_assets::CreateReservedAssets;

--- a/runtime/src/migrations/reserved_assets.rs
+++ b/runtime/src/migrations/reserved_assets.rs
@@ -1,0 +1,264 @@
+//! Migration to create reserved assets in pallet-assets (Instance2).
+//!
+//! Creates:
+//! - Asset 0: XCAV (Native token representation)
+//! - Asset 1: tGBP (Bridged stablecoin)
+//!
+//! This migration is idempotent - it checks if assets exist before creating them.
+
+use frame_support::{
+    storage::migration::get_storage_value, traits::OnRuntimeUpgrade, weights::Weight, BoundedVec,
+};
+use pallet_assets::Instance2;
+use sp_core::crypto::Ss58Codec;
+use sp_runtime::traits::Zero;
+#[cfg(feature = "try-runtime")]
+use {
+    alloc::vec::Vec,
+    frame_support::ensure,
+    parity_scale_codec::{Decode, Encode},
+    sp_runtime::TryRuntimeError,
+};
+
+use crate::{
+    constants::{
+        currency::MILLIXCAV,
+        known_assets::{NATIVE_ASSET_ID, TGBP_ASSET_ID},
+    },
+    AccountId, Balance, Runtime,
+};
+
+const LOG_TARGET: &str = "runtime::migrations::reserved_assets";
+
+/// Minimum balance for tGBP (18 decimals, 1 unit = 10^18)
+const TGBP_MIN_BALANCE: Balance = 1_000_000_000_000_000_000;
+
+/// Expected sudo key (SS58 format) for this migration.
+///
+/// ⚠️  IMPORTANT: Update this value before deploying to a new environment!
+///
+/// This is a safety check to ensure the migration runs with the expected sudo key.
+/// The sudo account will become the owner/admin of the reserved assets.
+const EXPECTED_SUDO_KEY_SS58: &str = "12DvowjMsZ8cVwnZCiUEMDNUAuZgMErxRx7LAb5f85maiCT4";
+
+/// Migration that creates reserved assets (XCAV at ID 0, tGBP at ID 1).
+///
+/// The assets are created with the sudo account as owner/admin/issuer/freezer.
+/// This migration is idempotent - if assets already exist, it skips creation.
+pub struct CreateReservedAssets;
+
+impl OnRuntimeUpgrade for CreateReservedAssets {
+    fn on_runtime_upgrade() -> Weight {
+        let mut reads = 0u64;
+        let mut writes = 0u64;
+
+        // Get sudo key - required for asset ownership.
+        let sudo_key: Option<AccountId> = get_storage_value(b"Sudo", b"Key", &[]);
+        let sudo_key = match sudo_key {
+            Some(key) => key,
+            None => {
+                log::error!(
+                    target: LOG_TARGET,
+                    "Sudo key not set - cannot create reserved assets"
+                );
+                return Weight::zero();
+            }
+        };
+        reads += 1;
+
+        // Verify sudo key matches expected value
+        let expected_sudo_key = match AccountId::from_ss58check(EXPECTED_SUDO_KEY_SS58) {
+            Ok(key) => key,
+            Err(e) => {
+                log::error!(
+                    target: LOG_TARGET,
+                    "Invalid EXPECTED_SUDO_KEY_SS58 constant: {:?}",
+                    e
+                );
+                return Weight::zero();
+            }
+        };
+
+        if sudo_key != expected_sudo_key {
+            log::error!(
+                target: LOG_TARGET,
+                "Sudo key mismatch! Expected {:?}, got {:?}. \
+                Update EXPECTED_SUDO_KEY_SS58 in migrations/reserved_assets.rs",
+                expected_sudo_key,
+                sudo_key
+            );
+            return Weight::zero();
+        }
+
+        log::info!(
+            target: LOG_TARGET,
+            "Sudo key verified: {}",
+            EXPECTED_SUDO_KEY_SS58
+        );
+
+        // Create Asset 0: XCAV
+        if !pallet_assets::Asset::<Runtime, Instance2>::contains_key(NATIVE_ASSET_ID) {
+            create_asset(NATIVE_ASSET_ID, &sudo_key, MILLIXCAV, b"Xcavate", b"XCAV", 12);
+            writes += 2; // Asset + Metadata
+            log::info!(
+                target: LOG_TARGET,
+                "Created XCAV asset (ID={})",
+                NATIVE_ASSET_ID
+            );
+        } else {
+            log::warn!(
+                target: LOG_TARGET,
+                "XCAV asset (ID={}) already exists, skipping",
+                NATIVE_ASSET_ID
+            );
+        }
+        reads += 1;
+
+        // Create Asset 1: tGBP
+        if !pallet_assets::Asset::<Runtime, Instance2>::contains_key(TGBP_ASSET_ID) {
+            create_asset(TGBP_ASSET_ID, &sudo_key, TGBP_MIN_BALANCE, b"Tokenised GBP", b"tGBP", 18);
+            writes += 2; // Asset + Metadata
+            log::info!(
+                target: LOG_TARGET,
+                "Created tGBP asset (ID={})",
+                TGBP_ASSET_ID
+            );
+        } else {
+            log::warn!(
+                target: LOG_TARGET,
+                "tGBP asset (ID={}) already exists, skipping",
+                TGBP_ASSET_ID
+            );
+        }
+        reads += 1;
+
+        log::info!(
+            target: LOG_TARGET,
+            "Migration complete: {} reads, {} writes",
+            reads,
+            writes
+        );
+
+        <Runtime as frame_system::Config>::DbWeight::get().reads_writes(reads, writes)
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+        let xcav_exists = pallet_assets::Asset::<Runtime, Instance2>::contains_key(NATIVE_ASSET_ID);
+        let tgbp_exists = pallet_assets::Asset::<Runtime, Instance2>::contains_key(TGBP_ASSET_ID);
+
+        log::info!(
+            target: LOG_TARGET,
+            "pre_upgrade: XCAV exists={}, tGBP exists={}",
+            xcav_exists,
+            tgbp_exists
+        );
+
+        Ok((xcav_exists, tgbp_exists).encode())
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
+        let (xcav_existed, tgbp_existed): (bool, bool) =
+            Decode::decode(&mut &state[..]).map_err(|_| "Failed to decode pre_upgrade state")?;
+
+        // XCAV should exist after migration
+        ensure!(
+            pallet_assets::Asset::<Runtime, Instance2>::contains_key(NATIVE_ASSET_ID),
+            "XCAV asset not created"
+        );
+
+        // tGBP should exist after migration
+        ensure!(
+            pallet_assets::Asset::<Runtime, Instance2>::contains_key(TGBP_ASSET_ID),
+            "tGBP asset not created"
+        );
+
+        // Verify XCAV details if newly created
+        if !xcav_existed {
+            let xcav = pallet_assets::Asset::<Runtime, Instance2>::get(NATIVE_ASSET_ID)
+                .ok_or("XCAV asset details missing")?;
+            ensure!(xcav.min_balance == MILLIXCAV, "XCAV min_balance incorrect");
+            ensure!(xcav.status == pallet_assets::AssetStatus::Live, "XCAV not Live");
+
+            let meta = pallet_assets::Metadata::<Runtime, Instance2>::get(NATIVE_ASSET_ID);
+            ensure!(meta.decimals == 12, "XCAV decimals incorrect");
+            ensure!(meta.symbol.as_slice() == b"XCAV", "XCAV symbol incorrect");
+        }
+
+        // Verify tGBP details if newly created
+        if !tgbp_existed {
+            let tgbp = pallet_assets::Asset::<Runtime, Instance2>::get(TGBP_ASSET_ID)
+                .ok_or("tGBP asset details missing")?;
+            ensure!(tgbp.min_balance == TGBP_MIN_BALANCE, "tGBP min_balance incorrect");
+            ensure!(tgbp.status == pallet_assets::AssetStatus::Live, "tGBP not Live");
+
+            let meta = pallet_assets::Metadata::<Runtime, Instance2>::get(TGBP_ASSET_ID);
+            ensure!(meta.decimals == 18, "tGBP decimals incorrect");
+            ensure!(meta.symbol.as_slice() == b"tGBP", "tGBP symbol incorrect");
+        }
+
+        log::info!(target: LOG_TARGET, "post_upgrade checks passed");
+        Ok(())
+    }
+}
+
+/// Helper function to create an asset and its metadata.
+fn create_asset(
+    asset_id: u32,
+    owner: &AccountId,
+    min_balance: Balance,
+    name: &[u8],
+    symbol: &[u8],
+    decimals: u8,
+) {
+    type StringLimit = <Runtime as pallet_assets::Config<Instance2>>::StringLimit;
+
+    let asset_details = pallet_assets::AssetDetails {
+        owner: owner.clone(),
+        issuer: owner.clone(),
+        admin: owner.clone(),
+        freezer: owner.clone(),
+        supply: Zero::zero(),
+        deposit: Zero::zero(),
+        min_balance,
+        is_sufficient: false,
+        accounts: 0,
+        sufficients: 0,
+        approvals: 0,
+        status: pallet_assets::AssetStatus::Live,
+    };
+
+    let bounded_name: BoundedVec<u8, StringLimit> =
+        name.to_vec().try_into().expect("asset name too long");
+    let bounded_symbol: BoundedVec<u8, StringLimit> =
+        symbol.to_vec().try_into().expect("asset symbol too long");
+
+    let metadata = pallet_assets::AssetMetadata {
+        deposit: Zero::zero(),
+        name: bounded_name,
+        symbol: bounded_symbol,
+        decimals,
+        is_frozen: false,
+    };
+
+    pallet_assets::Asset::<Runtime, Instance2>::insert(asset_id, asset_details);
+    pallet_assets::Metadata::<Runtime, Instance2>::insert(asset_id, metadata);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tgbp_min_balance_is_one_unit() {
+        // 1 unit with 18 decimals = 10^18
+        assert_eq!(TGBP_MIN_BALANCE, 1_000_000_000_000_000_000);
+    }
+
+    #[test]
+    fn xcav_min_balance_matches_native_ed() {
+        // MILLIXCAV = 1_000_000_000 (native ED)
+        assert_eq!(MILLIXCAV, 1_000_000_000);
+    }
+}

--- a/runtime/src/types.rs
+++ b/runtime/src/types.rs
@@ -67,6 +67,12 @@ pub type TxExtension = cumulus_pallet_weight_reclaim::StorageWeightReclaim<
 pub type UncheckedExtrinsic =
     generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, TxExtension>;
 
+/// All migrations that run on runtime upgrade.
+///
+/// This tuple contains migrations that will execute during the `on_runtime_upgrade` hook.
+/// Migrations should be idempotent and check for pre-existing state before making changes.
+pub type Migrations = (crate::migrations::CreateReservedAssets,);
+
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
     Runtime,
@@ -74,6 +80,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    Migrations,
 >;
 
 /// Price For Sibling Parachain Delivery

--- a/runtime/tests/constants_test.rs
+++ b/runtime/tests/constants_test.rs
@@ -18,12 +18,12 @@ mod constant_tests {
 
 mod runtime_tests {
     use frame_support::{pallet_prelude::Weight, traits::TypedGet, PalletId};
+    use sp_version::RuntimeVersion;
     use xcavate_runtime::{
         configs::*,
         constants::{currency::*, *},
         *,
     };
-    use sp_version::RuntimeVersion;
     use xcm::latest::prelude::BodyId;
     extern crate alloc;
 
@@ -35,7 +35,7 @@ mod runtime_tests {
                 spec_name: alloc::borrow::Cow::Borrowed("template-parachain"),
                 impl_name: alloc::borrow::Cow::Borrowed("template-parachain"),
                 authoring_version: 1,
-                spec_version: 8,
+                spec_version: 9,
                 impl_version: 0,
                 apis: xcavate_runtime::apis::RUNTIME_API_VERSIONS,
                 transaction_version: 7,
@@ -66,7 +66,7 @@ mod runtime_tests {
         assert_eq!(AVERAGE_ON_INITIALIZE_RATIO, Perbill::from_percent(5));
 
         assert_eq!(NORMAL_DISPATCH_RATIO, Perbill::from_percent(75));
- 
+
         assert_eq!(UNINCLUDED_SEGMENT_CAPACITY, 3);
 
         assert_eq!(BLOCK_PROCESSING_VELOCITY, 1);

--- a/runtime/tests/multiplier.rs
+++ b/runtime/tests/multiplier.rs
@@ -2,10 +2,10 @@
 mod common;
 use common::*;
 use frame_support::pallet_prelude::*;
-use xcavate_runtime::{Runtime, RuntimeBlockWeights};
 use pallet_transaction_payment::Multiplier;
 use polkadot_runtime_common::MinimumMultiplier;
 use sp_runtime::{traits::Convert, Perquintill};
+use xcavate_runtime::{Runtime, RuntimeBlockWeights};
 
 fn min_multiplier() -> Multiplier {
     MinimumMultiplier::get()

--- a/zombienet-config/README.md
+++ b/zombienet-config/README.md
@@ -1,23 +1,60 @@
-# Zombienet configuration
+# Zombienet Configuration
 
-Zombienet aims to be a testing framework for Substrate based blockchains, providing a simple cli tool that allows users to spawn and test ephemeral networks.
+Zombienet is a testing framework for Substrate-based blockchains that allows you to spawn and test ephemeral networks.
 
-## Start a development chain
+## Quick Start with Pop CLI (Recommended)
 
-Firstly build Polkadot binaries with:
+The easiest way to run a local network is using [Pop CLI](https://onpop.io). Pop can launch networks directly from zombienet configuration files and handles all required binary downloads automatically.
+
+### Install Pop CLI
+
+**macOS (Homebrew):**
+```sh
+brew install r0gue-io/pop-cli/pop
+```
+
+**All platforms (Cargo):**
+```sh
+cargo install pop-cli
+```
+
+### Launch the Network
+
+1. Build the xcavate node:
+   ```sh
+   cargo build
+   ```
+
+2. Start the local Paseo network with xcavate parachain:
+   ```sh
+   pop up zombienet-config/paseo-local.toml
+   ```
+
+Pop will automatically download the required relay chain binaries and bootstrap the network. Once running, you can access:
+
+- **Relay chain (Alice):** `ws://localhost:9900`
+- **Xcavate parachain:** `ws://localhost:9920`
+
+---
+
+## Alternative: Manual Setup
+
+If you prefer not to use Pop CLI, you can use the zombienet scripts directly.
+
+### Build Polkadot binaries
 
 ```sh
-$ scripts/zombienet.sh build
+scripts/zombienet.sh build
 ```
 
-This process can take some time, so please be patient. If on Linux, you can alternatively download the binaries to speed up the process with:
+This process can take some time. On Linux, you can alternatively download pre-built binaries:
 
-```shell
-$ scripts/zombinet.sh init
+```sh
+scripts/zombienet.sh init
 ```
 
-Once Polkadot binaries are in place you can spawn a local testnet by running the following command:
+### Spawn the network
 
-```shell
-$ scripts/zombienet.sh devnet
+```sh
+scripts/zombienet.sh devnet
 ```

--- a/zombienet-config/paseo-local.toml
+++ b/zombienet-config/paseo-local.toml
@@ -1,0 +1,30 @@
+[relaychain]
+chain = "paseo-local"
+
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+rpc_port = 9900
+
+[[relaychain.nodes]]
+name = "bob"
+validator = true
+
+#[[parachains]]
+#id = 1000
+#chain = "asset-hub-paseo-local"
+#
+#[[parachains.collators]]
+#name = "asset-hub-collator01"
+#rpc_port = 9910
+#args = ["-lxcm=trace,pallet-assets=trace"]
+
+[[parachains]]
+id = 2000
+default_command = "./target/debug/xcavate-node"
+chain = "dev"
+
+[[parachains.collators]]
+name = "xcav-collator01"
+rpc_port = 9920
+args = ["-lxcm=trace,pallet-assets=trace"]


### PR DESCRIPTION
# Runtime Migration: Reserve Asset IDs for ISMP Integration

## Summary

This PR introduces a runtime migration that reserves Asset IDs 0 and 1 in `pallet-assets` (Instance2) for the native XCAV token and bridged tGBP stablecoin respectively. These asset IDs are required by the ISMP/Token Gateway configuration but were not previously created on-chain.

Additionally, this PR includes improved local development tooling via zombienet configuration updates.

---

## ⚠️ Review Note

This PR is built on top of [#15 (Hyperbridge Integration: Documentation Overhaul & Runtime Improvements)](https://github.com/XcavateBlockchain/xcavate-node-paseo/pull/15). Until PR #15 is merged into `feat/ismp` and this branch (`feat/ismp-reserve-assetids`) is rebased, reviewers will see changes from both PRs in the diff.

**Recommendation:** Review PR #15 first, then review this PR focusing on the migration-specific changes listed below.

---

## Background

The ISMP integration defines constants `NATIVE_ASSET_ID = 0` and `TGBP_ASSET_ID = 1` in `runtime/src/constants.rs`, which are referenced by the Token Gateway configuration. However, these assets did not exist in `pallet-assets` storage, which would cause issues when the Token Gateway attempts to interact with them.

This migration ensures the assets are created during runtime upgrade, with proper metadata and ownership configured.

---

## Changes

### 1. Runtime Migration (`runtime/src/migrations/`)

**New files:**
- `mod.rs` – Migration module exports
- `reserved_assets.rs` – Migration implementation

**Migration behavior:**

| Asset ID | Name | Symbol | Decimals | Min Balance | Owner |
|----------|------|--------|----------|-------------|-------|
| 0 | Xcavate | XCAV | 12 | 1 MILLIXCAV | Sudo account |
| 1 | Tokenised GBP | tGBP | 18 | 1 unit (10¹⁸) | Sudo account |

**Safety features:**
- **Idempotent**: Checks if assets exist before creating; safe to re-run
- **Sudo key verification**: Validates the on-chain sudo key matches `EXPECTED_SUDO_KEY_SS58` constant before proceeding
- **Accurate weight reporting**: Returns precise read/write counts
- **try-runtime support**: Includes `pre_upgrade` and `post_upgrade` hooks for testing

### 2. Executive Integration (`runtime/src/types.rs`)

```rust
pub type Migrations = (crate::migrations::CreateReservedAssets,);

pub type Executive = frame_executive::Executive<
    Runtime,
    Block,
    frame_system::ChainContext<Runtime>,
    Runtime,
    AllPalletsWithSystem,
    Migrations,  // Added
>;
```

### 3. Version Bump (`runtime/src/constants.rs`)

```rust
spec_version: 9,  // Incremented from 8
```

### 4. Zombienet Improvements

**New configuration:** `zombienet-config/paseo-local.toml`
- Paseo-local relay chain with Alice and Bob validators
- Xcavate parachain (ID 2000) with debug logging

**Updated documentation:** `zombienet-config/README.md`
- Added Pop CLI quick start guide (recommended approach)
- Preserved manual setup instructions as alternative
- Documented network endpoints

---

## Files Changed

| File | Change |
|------|--------|
| `runtime/src/migrations/mod.rs` | New |
| `runtime/src/migrations/reserved_assets.rs` | New |
| `runtime/src/lib.rs` | Added `mod migrations` |
| `runtime/src/types.rs` | Added `Migrations` type to Executive |
| `runtime/src/constants.rs` | Bumped `spec_version` to 9 |
| `runtime/src/configs/ismp.rs` | Import formatting cleanup |
| `runtime/tests/constants_test.rs` | Updated expected `spec_version` |
| `runtime/tests/multiplier.rs` | Import ordering cleanup |
| `runtime/build.rs` | Formatting cleanup |
| `zombienet-config/paseo-local.toml` | New |
| `zombienet-config/README.md` | Expanded with Pop CLI instructions |

---

## Deployment Notes

### Pre-deployment Checklist

1. **Verify sudo key**: Update `EXPECTED_SUDO_KEY_SS58` in `runtime/src/migrations/reserved_assets.rs` to match the target environment's sudo account:
   ```rust
   const EXPECTED_SUDO_KEY_SS58: &str = "12DvowjMsZ8cVwnZCiUEMDNUAuZgMErxRx7LAb5f85maiCT4";
   ```

2. **Build and test**:
   ```bash
   cargo check -p xcavate-runtime
   cargo test -p xcavate-runtime
   ```

3. **Optional: try-runtime verification**:
   ```bash
   cargo build --release --features try-runtime
   try-runtime --runtime ./target/release/wbuild/xcavate-runtime/xcavate_runtime.wasm \
       on-runtime-upgrade live --uri <xcavate-endpoint>
   ```

### Migration Behavior

- If sudo key does not match: Migration logs an error and exits without changes
- If assets already exist: Migration skips creation and logs a warning
- On success: Assets are created with sudo account as owner/admin/issuer/freezer

---

## Testing

**Test coverage:**
- `tgbp_min_balance_is_one_unit` – Verifies tGBP minimum balance constant
- `xcav_min_balance_matches_native_ed` – Verifies XCAV minimum balance matches native existential deposit
- Runtime version test updated for `spec_version: 9`

### try-runtime Dry Run

The migration has been successfully tested against live chain state using `try-runtime`:

```
[INFO  runtime::migrations::reserved_assets] pre_upgrade: XCAV exists=false, tGBP exists=false
[INFO  runtime::migrations::reserved_assets] Sudo key verified: 12DvowjMsZ8cVwnZCiUEMDNUAuZgMErxRx7LAb5f85maiCT4
[INFO  runtime::migrations::reserved_assets] Created XCAV asset (ID=0)
[INFO  runtime::migrations::reserved_assets] Created tGBP asset (ID=1)
[INFO  runtime::migrations::reserved_assets] Migration complete: 3 reads, 4 writes
[INFO  runtime::migrations::reserved_assets] post_upgrade checks passed
[INFO  runtime::executive] ✅ Entire runtime state decodes without error. 11462 bytes total.
[INFO  try-runtime::cli] PoV size (zstd-compressed compact proof): 2.1 KB
[INFO  try-runtime::cli] Consumed ref_time: 0.00044s (0.02% of max 2s)
[INFO  try-runtime::cli] ✅ No weight safety issues detected.
```

---

## Local Development

After merging, developers can spin up a local network using:

```bash
cargo build
pop up zombienet-config/paseo-local.toml
```

See `zombienet-config/README.md` for detailed instructions.
