### PR TITLE
docs(ismp): refine documentation including USD.h example

### DIFF
--- a/docs/hyperbridge-integration/BRIDGING_ERC20.md
+++ b/docs/hyperbridge-integration/BRIDGING_ERC20.md
@@ -24,8 +24,9 @@ Complete guide for bridging existing ERC-20 tokens from Ethereum to the Xcavate 
    - [Xcavate → Ethereum](#xcavate--ethereum)
    - [Timeline](#timeline)
 5. [Working Example: tGBP](#working-example-tgbp)
-6. [Troubleshooting](#troubleshooting)
-7. [Reference](#reference)
+6. [Working Example: USD.h (Sepolia Testnet)](#working-example-usdh-sepolia-testnet)
+7. [Troubleshooting](#troubleshooting)
+8. [Reference](#reference)
 
 ---
 
@@ -250,7 +251,7 @@ TokenGateway::create_erc6160_asset(
             symbol: b"tGBP".to_vec(),  // Must match ERC-20 exactly
             name: b"Tokenised GBP".to_vec(),
             chains: vec![StateMachine::Evm(1)],  // Ethereum Mainnet
-            minimum_balance: Some(1),
+            minimum_balance: None,
         },
 
         // ERC-20 decimals on each source chain
@@ -299,9 +300,11 @@ tokenGateway.precisions(1, Evm(1)) → Some(18)  // 18 decimals on Mainnet
 **On Ethereum:**
 ```javascript
 const assetId = ethers.keccak256(ethers.toUtf8Bytes('tGBP'));
-const erc20 = await tokenGateway.erc20(assetId);    // Original tGBP address
-const erc6160 = await tokenGateway.erc6160(assetId); // Wrapper address
+const erc20 = await tokenGateway.erc20(assetId);    // ERC-20 address (if registered)
+const erc6160 = await tokenGateway.erc6160(assetId); // ERC6160 address (if registered)
 ```
+
+A token is considered registered on the TokenGateway if it has an address in either the `erc20()` or `erc6160()` mapping. The specific mapping used depends on the token type and how it was registered.
 
 ---
 
@@ -324,7 +327,7 @@ await tokenGateway.teleport({
     assetId: ethers.keccak256(ethers.toUtf8Bytes('tGBP')),
     redeem: false,
     to: recipientAccountId,  // 32-byte Substrate account
-    dest: ethers.toUtf8Bytes('PASEO-4683'),
+    dest: ethers.toUtf8Bytes('KUSAMA-4683'),
     timeout: 3600,
     nativeCost: 0,
     data: '0x'
@@ -373,6 +376,78 @@ TokenGateway::teleport(
 | Relay | ~1-2 min | Relayer delivers to Xcavate |
 | Processing | ~12 sec | Xcavate mints tokens |
 | **Total** | **~20-30 min** | |
+
+---
+
+## Working Example: USD.h (Sepolia Testnet)
+
+This example demonstrates a successful bridge transfer of 10 USD.h from Ethereum Sepolia to Xcavate testnet.
+
+### Token Info
+
+| Property | Sepolia Testnet |
+|----------|-----------------|
+| Contract | [`0xa801da100bf16d07f668f4a49e1f71fc54d05177`](https://sepolia.etherscan.io/address/0xa801da100bf16d07f668f4a49e1f71fc54d05177) |
+| Symbol | USD.h |
+| Decimals | 18 |
+| Asset ID | `0x829f01563df2ff9752a529f62c33a4b03b805da1e1dfc748127d6d37795d7257` |
+
+The Asset ID is computed as `keccak256("USD.h")`.
+
+### Reference Transaction
+
+A successful teleport transaction can be found here:
+[`0x68b6f0e6850550fcc5100b50f01b83aa93d898609e749e08a2d4635c12752134`](https://sepolia.etherscan.io/tx/0x68b6f0e6850550fcc5100b50f01b83aa93d898609e749e08a2d4635c12752134)
+
+### Teleport Parameters Used
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `amount` | `10000000000000000000` | 10 USD.h (18 decimals) |
+| `relayerFee` | `0` | No relayer fee |
+| `assetId` | `0x829f01563df2ff9752a529f62c33a4b03b805da1e1dfc748127d6d37795d7257` | keccak256("USD.h") |
+| `redeem` | `false` | Mint on destination |
+| `to` | `0x36185119e347676ff4eb6041ae90d638f6213cd471c53ced8a52ccb8fa84bc32` | Recipient (bytes32) |
+| `dest` | `0x4b5553414d412d34363833` | "KUSAMA-4683" encoded |
+| `timeout` | `3600` | 1 hour |
+| `nativeCost` | `0` | No native cost |
+| `data` | `0x` | Empty |
+
+### Reproducing This Transfer
+
+The transfer involves two operations:
+
+1. **Approve** - Allow the TokenGateway contract to spend your USD.h tokens
+2. **Teleport** - Call the TokenGateway to initiate the cross-chain transfer
+
+```javascript
+// 1. Approve TokenGateway to spend USD.h
+const usdh = new ethers.Contract('0xa801da100bf16d07f668f4a49e1f71fc54d05177', ERC20_ABI, wallet);
+await usdh.approve('0xFcDa26cA021d5535C3059547390E6cCd8De7acA6', ethers.parseUnits('10', 18));
+
+// 2. Teleport tokens to Xcavate
+const gateway = new ethers.Contract('0xFcDa26cA021d5535C3059547390E6cCd8De7acA6', GATEWAY_ABI, wallet);
+await gateway.teleport({
+    amount: ethers.parseUnits('10', 18),
+    relayerFee: 0n,
+    assetId: '0x829f01563df2ff9752a529f62c33a4b03b805da1e1dfc748127d6d37795d7257',
+    redeem: false,
+    to: recipientBytes32,
+    dest: ethers.toUtf8Bytes('KUSAMA-4683'),
+    timeout: 3600n,
+    nativeCost: 0n,
+    data: '0x'
+});
+```
+
+> **Note:** The integration test script handles both operations automatically. To use it:
+> ```bash
+> cd integration-tests
+> npm install
+> npm run teleport              # Preview (no transaction)
+> PRIVATE_KEY=0x... npm run teleport:execute  # Execute
+> ```
+> Edit the `CONFIG` object in `src/sepolia/teleport-erc20.js` to customize the amount or recipient.
 
 ---
 
@@ -448,7 +523,7 @@ async function bridge(wallet, amount, recipient) {
         assetId: ethers.keccak256(ethers.toUtf8Bytes('tGBP')),
         redeem: false,
         to: recipient,  // 32-byte account ID
-        dest: ethers.toUtf8Bytes('PASEO-4683'),
+        dest: ethers.toUtf8Bytes('KUSAMA-4683'),
         timeout: 3600n,
         nativeCost: 0n,
         data: '0x'

--- a/docs/hyperbridge-integration/README.md
+++ b/docs/hyperbridge-integration/README.md
@@ -114,7 +114,7 @@ Transfers take approximately **20-30 minutes** due to Ethereum finalization time
 | Network | Token | Address | Decimals | Asset ID |
 |---------|-------|---------|----------|----------|
 | Ethereum Mainnet | tGBP | [`0x27f6c8289550fCE67f6B50BeD1F519966aFE5287`](https://etherscan.io/address/0x27f6c8289550fCE67f6B50BeD1F519966aFE5287) | 18 | `0x99bb...c843` |
-| Sepolia Testnet | WETH | [`0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14`](https://sepolia.etherscan.io/address/0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14) | 18 | `0x0f8a...b5b8` |
+| Sepolia Testnet | USD.h | [`0xa801da100bf16d07f668f4a49e1f71fc54d05177`](https://sepolia.etherscan.io/address/0xa801da100bf16d07f668f4a49e1f71fc54d05177) | 18 | `0x829f...7257` |
 
 ---
 
@@ -161,7 +161,7 @@ await tokenGateway.teleport({
     amount: amount,
     assetId: ethers.keccak256(ethers.toUtf8Bytes('tGBP')),
     to: recipientAccountId,  // 32-byte Substrate account
-    dest: ethers.toUtf8Bytes('PASEO-4683'),
+    dest: ethers.toUtf8Bytes('KUSAMA-4683'),
     timeout: 3600,
     relayerFee: 0,
     redeem: false,

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -32,7 +32,7 @@ npm run verify-registration
 | Network | Token | Address | Asset ID |
 |---------|-------|---------|----------|
 | **Ethereum Mainnet** | tGBP | [`0x27f6c8289550fCE67f6B50BeD1F519966aFE5287`](https://etherscan.io/address/0x27f6c8289550fCE67f6B50BeD1F519966aFE5287) | `0x99bb6e8574d7a5293a476638667ca3492c7e3f9ae2f5a47457f96c3c5c7fc843` |
-| **Sepolia Testnet** | WETH | [`0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14`](https://sepolia.etherscan.io/address/0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14) | `0x0f8a193ff464434486c0daf7db2a895884365d2bc84ba47a68fcf89c1b14b5b8` |
+| **Sepolia Testnet** | USD.h | [`0xa801da100bf16d07f668f4a49e1f71fc54d05177`](https://sepolia.etherscan.io/address/0xa801da100bf16d07f668f4a49e1f71fc54d05177) | `0x829f01563df2ff9752a529f62c33a4b03b805da1e1dfc748127d6d37795d7257` |
 
 Asset IDs are computed as `keccak256(symbol)` and are deterministic across all chains.
 
@@ -91,7 +91,7 @@ JavaScript scripts for live testnet interaction. See [`src/sepolia/README.md`](s
 
 | Script | Command | Description |
 |--------|---------|-------------|
-| `teleport-erc20.js` | `npm run teleport` | Prepare WETH bridge from Sepolia to Xcavate |
+| `teleport-erc20.js` | `npm run teleport` | Prepare USD.h bridge from Sepolia to Xcavate |
 | `teleport-erc20.js --execute` | `npm run teleport:execute` | Execute actual bridge transaction |
 | `verify-registration.js` | `npm run verify-registration` | Check if token is registered on TokenGateway |
 | `calculate-asset-id.js` | `npm run calc-asset-id` | Calculate keccak256 asset ID for a symbol |
@@ -111,9 +111,9 @@ TELEPORT ERC-20 TOKENS: Ethereum -> Xcavate
 ================================================================================
 
 Transfer Configuration:
-  Token:       WETH (0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14)
-  Amount:      0.001 WETH
-  Destination: PASEO-4683
+  Token:       USD.h (0xa801da100bf16d07f668f4a49e1f71fc54d05177)
+  Amount:      10 USD.h
+  Destination: KUSAMA-4683
   Mode:        PREPARE (no transaction)
 ```
 

--- a/integration-tests/src/sepolia/README.md
+++ b/integration-tests/src/sepolia/README.md
@@ -15,17 +15,17 @@ npm install ethers @polkadot/util-crypto
 - `tokenGateway.abi` - TokenGateway contract ABI
 - `endpoints` - List of Sepolia RPC endpoints
 
-## Test Token: WETH
+## Test Token: USD.h
 
-For Sepolia testing, we use **WETH (Wrapped Ether)** which is readily available on the testnet.
+For Sepolia testing, we use **USD.h** which has been successfully tested for bridging to Xcavate.
 
 | Token | Address | Decimals | Asset ID |
 |-------|---------|----------|----------|
-| WETH | [`0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14`](https://sepolia.etherscan.io/address/0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14) | 18 | `0x0f8a193ff464434486c0daf7db2a895884365d2bc84ba47a68fcf89c1b14b5b8` |
+| USD.h | [`0xa801da100bf16d07f668f4a49e1f71fc54d05177`](https://sepolia.etherscan.io/address/0xa801da100bf16d07f668f4a49e1f71fc54d05177) | 18 | `0x829f01563df2ff9752a529f62c33a4b03b805da1e1dfc748127d6d37795d7257` |
 
-The Asset ID is `keccak256("WETH")` and is used to identify the token on the TokenGateway contract.
+The Asset ID is `keccak256("USD.h")` and is used to identify the token on the TokenGateway contract.
 
-**Note:** On Ethereum Mainnet, tGBP (Tokenised GBP) is the primary bridged asset with Asset ID `0x99bb6e8574d7a5293a476638667ca3492c7e3f9ae2f5a47457f96c3c5c7fc843`. See the main documentation at `/docs/ismp-token-gateway/` for mainnet examples.
+**Alternative:** WETH (Wrapped Ether) at `0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14` can also be used for testing if registered.
 
 ## Contract Addresses (Sepolia - Gargantua V3)
 
@@ -58,17 +58,17 @@ npm run teleport
 PRIVATE_KEY=0x... npm run teleport:execute
 ```
 
-**Default Configuration (WETH):**
+**Default Configuration (USD.h):**
 ```javascript
 const CONFIG = {
     token: {
-        symbol: 'WETH',
-        address: '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14',
+        symbol: 'USD.h',
+        address: '0xa801da100bf16d07f668f4a49e1f71fc54d05177',
         decimals: 18,
     },
-    amount: '0.001',           // Amount to bridge (0.001 WETH)
+    amount: '10',              // Amount to bridge (10 USD.h)
     recipient: '5Grwva...',    // Xcavate SS58 address
-    destination: 'PASEO-4683', // Xcavate on Paseo
+    destination: 'KUSAMA-4683', // Xcavate testnet (para ID 4683)
     timeout: 3600,             // 1 hour
 };
 ```
@@ -80,14 +80,16 @@ const CONFIG = {
 
 ### verify-registration.js
 
-Verifies that WETH (or other token) is properly registered on the TokenGateway contract.
+Verifies that USD.h (or other token) is properly registered on the TokenGateway contract.
 
-**Default Token:** WETH (Wrapped Ether) - 18 decimals
+**Default Token:** USD.h - 18 decimals
 
 **What it checks:**
-1. ERC20 token registration
-2. ERC6160 wrapper deployment
+1. ERC20 token registration (via `erc20()` mapping)
+2. ERC6160 token registration (via `erc6160()` mapping)
 3. Overall registration status
+
+A token is considered registered if it appears in either the `erc20()` or `erc6160()` mapping.
 
 **Usage:**
 ```bash
@@ -125,7 +127,7 @@ npm run calc-asset-id -- WETH
 | Network | Sepolia Testnet |
 | Chain ID | 11155111 |
 | Block Explorer | https://sepolia.etherscan.io |
-| Destination | `PASEO-4683` |
+| Destination | `KUSAMA-4683` |
 
 ## Troubleshooting
 

--- a/integration-tests/src/sepolia/teleport-erc20.js
+++ b/integration-tests/src/sepolia/teleport-erc20.js
@@ -1,7 +1,7 @@
 /**
  * Teleport ERC-20 Tokens from Ethereum to Xcavate
  *
- * This script demonstrates how a user bridges ERC-20 tokens (e.g., WETH, USDC)
+ * This script demonstrates how a user bridges ERC-20 tokens (e.g., USD.h, WETH)
  * from Ethereum to Xcavate via the Hyperbridge TokenGateway.
  *
  * Prerequisites:
@@ -27,22 +27,28 @@ const path = require('path');
 // ============================================================================
 
 const CONFIG = {
-    // Token to bridge - WETH (Wrapped Ether) on Sepolia
-    // WETH is readily available on Sepolia for testing
+    // Token to bridge - USD.h on Sepolia.
+    // This token has been successfully tested for bridging to Xcavate
     token: {
-        symbol: 'WETH',
-        address: '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14', // WETH on Sepolia
+        symbol: 'USD.h',
+        address: '0xa801da100bf16d07f668f4a49e1f71fc54d05177',
         decimals: 18,
     },
+    // Alternative: WETH (Wrapped Ether) on Sepolia
+    // token: {
+    //     symbol: 'WETH',
+    //     address: '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14',
+    //     decimals: 18,
+    // },
 
     // Amount to bridge (in human-readable format)
-    amount: '0.001', // 0.001 WETH (small amount for testing)
+    amount: '10', // 10 USD.h for testing
 
     // Recipient on Xcavate (SS58 address)
-    recipient: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', // Alice
+    recipient: '5DHdfcUJ1ms94Qn3F5RED4YKKHa2ewJpMTNr1J6JZzk4Xrpn', // Alice
 
     // Destination chain identifier for Xcavate on Paseo
-    destination: 'PASEO-4683',
+    destination: 'KUSAMA-4683',
 
     // Timeout in seconds (1 hour default)
     timeout: 3600,
@@ -209,13 +215,13 @@ async function teleportERC20() {
     console.log(`  ERC20 Address:  ${erc20Address}`);
     console.log(`  ERC6160 Address: ${erc6160Address}`);
 
-    if (erc20Address === ethers.ZeroAddress) {
+    if (erc20Address === ethers.ZeroAddress && erc6160Address === ethers.ZeroAddress) {
         console.error('\nERROR: Token is not registered on TokenGateway!');
         console.error('The token must be registered via create_erc6160_asset on Xcavate first.');
-        console.error('See: docs/ismp-token-gateway/BRIDGING_ERC20.md');
+        console.error('See: docs/hyperbridge-integration/BRIDGING_ERC20.md');
         process.exit(1);
     }
-    console.log('  Status: Token is registered');
+    console.log('  Please verify this state matches your expectations.');
     console.log();
 
     // Check balances (if we have a wallet)

--- a/integration-tests/src/sepolia/verify-registration.js
+++ b/integration-tests/src/sepolia/verify-registration.js
@@ -1,8 +1,12 @@
 /**
  * Verify Token Registration on Ethereum TokenGateway (Sepolia)
  *
- * This script checks if WETH (or other token) is properly registered
+ * This script checks if USD.h (or other token) is properly registered
  * on the TokenGateway contract on Sepolia.
+ *
+ * Note: A token can be registered under either the erc20() or erc6160() mapping:
+ * - erc20: Native ERC-20 tokens
+ * - erc6160: ERC6160 tokens or ERC-20/ERC6160 dual-standard tokens
  *
  * Usage: node verify-registration.js
  */
@@ -12,11 +16,11 @@ const fs = require('fs');
 const path = require('path');
 
 // ============================================================================
-// CONSTANTS - Token Information (WETH for Sepolia testing)
+// CONSTANTS - Token Information (USD.h for Sepolia testing)
 // ============================================================================
 const TOKEN_INFO = {
-    name: 'Wrapped Ether',
-    symbol: 'WETH',
+    name: 'USD.h',
+    symbol: 'USD.h',
     decimals: 18
 };
 
@@ -127,36 +131,26 @@ async function verifyRegistration() {
 
         // Summary
         console.log('='.repeat(80));
-        console.log('VERIFICATION SUMMARY');
+        console.log('TOKEN GATEWAY STATE');
         console.log('='.repeat(80));
         console.log();
+        console.log('Registration State:');
+        console.log(`  - ERC20:   ${erc20Address}`);
+        console.log(`  - ERC6160: ${erc6160Address}`);
+        console.log();
+        console.log('Please verify this state matches your expectations.');
+        console.log();
 
-        const fullyRegistered = isERC20Registered && isERC6160Deployed;
+        // Token is registered if EITHER erc20 OR erc6160 has an address
+        const isRegistered = isERC20Registered || isERC6160Deployed;
 
-        if (fullyRegistered) {
-            console.log('✓ SUCCESS: Token is fully registered and ready for bridging!');
-            console.log();
-            console.log('Details:');
-            console.log(`  - Native ERC20: ${erc20Address}`);
-            console.log(`  - ERC6160 Wrapper: ${erc6160Address}`);
-            console.log();
-            console.log('Next Steps:');
-            console.log('  - Users can now approve and teleport tokens from Ethereum to Xcavate');
-            console.log('  - Verify the ERC20 contract has correct decimals (should be 18)');
-            console.log('  - Test with a small amount first');
+        if (isRegistered) {
+            console.log('The token has at least one address registered on the TokenGateway.');
+            console.log('If this is the expected state, the token is ready for bridging.');
         } else {
-            console.log('✗ INCOMPLETE: Token registration is not complete');
+            console.log('Neither ERC20 nor ERC6160 address is registered for this token.');
             console.log();
-            console.log('Status:');
-            console.log(`  - ERC20 Registered: ${isERC20Registered ? 'YES' : 'NO'}`);
-            console.log(`  - ERC6160 Wrapper: ${isERC6160Deployed ? 'YES' : 'NO'}`);
-            console.log();
-            console.log('Possible Reasons:');
-            console.log('  1. Cross-chain message from Xcavate is still pending (~15-20 minutes)');
-            console.log('  2. create_erc6160_asset was not called on Xcavate yet');
-            console.log('  3. The registration failed - check Hyperbridge explorer');
-            console.log();
-            console.log('What to do:');
+            console.log('If registration is pending:');
             console.log('  - Wait 15-20 minutes after calling create_erc6160_asset on Xcavate');
             console.log('  - Run this script again to check status');
             console.log('  - Check Hyperbridge explorer for message status');


### PR DESCRIPTION
The changes in this PR integrate the details of the already proven bridging scenario. In this case some amount of USD.h was transferred from Ethereum Sepolia into Xcavate's testnet via Hyperbridge.

The documentation now shows the exact arguments that were used in that test scenario and adapts the integration test scripts such that this becomes the default case.

