### PR TITLE
fix(ismp::tGBP): name substitution

### DIFF
--- a/docs/hyperbridge-integration/BRIDGING_ERC20.md
+++ b/docs/hyperbridge-integration/BRIDGING_ERC20.md
@@ -225,7 +225,7 @@ Assets::create(
 Assets::set_metadata(
     RuntimeOrigin::signed(admin),
     1,
-    b"Tokenised GBP".to_vec(),
+    b"tGBP".to_vec(),
     b"tGBP".to_vec(),
     18,  // USE SAME DECIMALS AS ETHEREUM
 )?;
@@ -249,7 +249,7 @@ TokenGateway::create_erc6160_asset(
 
         reg: GatewayAssetRegistration {
             symbol: b"tGBP".to_vec(),  // Must match ERC-20 exactly
-            name: b"Tokenised GBP".to_vec(),
+            name: b"tGBP".to_vec(),
             chains: vec![StateMachine::Evm(1)],  // Ethereum Mainnet
             minimum_balance: None,
         },
@@ -477,7 +477,7 @@ TokenGateway::set_token_gateway_addresses(
 // 2. Create asset
 Assets::create(RuntimeOrigin::root(), 1, treasury(), 1)?;
 Assets::set_metadata(RuntimeOrigin::signed(admin()), 1,
-    b"Tokenised GBP".to_vec(), b"tGBP".to_vec(), 18)?;
+    b"tGBP".to_vec(), b"tGBP".to_vec(), 18)?;
 
 // 3. Register
 TokenGateway::create_erc6160_asset(RuntimeOrigin::root(), AssetRegistration {
@@ -485,7 +485,7 @@ TokenGateway::create_erc6160_asset(RuntimeOrigin::root(), AssetRegistration {
     native: false,
     reg: GatewayAssetRegistration {
         symbol: b"tGBP".to_vec(),
-        name: b"Tokenised GBP".to_vec(),
+        name: b"tGBP".to_vec(),
         chains: vec![StateMachine::Evm(1)],  // Ethereum Mainnet
         minimum_balance: Some(1),
     },

--- a/docs/hyperbridge-integration/README.md
+++ b/docs/hyperbridge-integration/README.md
@@ -125,7 +125,7 @@ Transfers take approximately **20-30 minutes** due to Ethereum finalization time
 ```rust
 // 1. Create asset on Xcavate
 Assets::create(RuntimeOrigin::root(), 1, admin, 1)?;
-Assets::set_metadata(origin, 1, b"Tokenised GBP".to_vec(), b"tGBP".to_vec(), 18)?;
+Assets::set_metadata(origin, 1, b"tGBP".to_vec(), b"tGBP".to_vec(), 18)?;
 
 // 2. Register with Token Gateway
 TokenGateway::create_erc6160_asset(
@@ -135,7 +135,7 @@ TokenGateway::create_erc6160_asset(
         native: false,  // Bridged from Ethereum
         reg: GatewayAssetRegistration {
             symbol: b"tGBP".to_vec(),
-            name: b"Tokenised GBP".to_vec(),
+            name: b"tGBP".to_vec(),
             chains: vec![StateMachine::Evm(1)],  // Ethereum Mainnet
             minimum_balance: Some(1),
         },

--- a/docs/hyperbridge-integration/reference/ASSET_REGISTRATION.md
+++ b/docs/hyperbridge-integration/reference/ASSET_REGISTRATION.md
@@ -210,7 +210,7 @@ AssetRegistration {
 
 ```rust
 symbol: "tGBP".as_bytes().to_vec(),  // Max 20 chars
-name: "Tokenised GBP".as_bytes().to_vec(),  // Max 20 chars
+name: "tGBP".as_bytes().to_vec(),  // Max 20 chars
 ```
 
 - Symbol is used to generate the asset ID: `keccak256(symbol)`
@@ -265,7 +265,7 @@ Assets::create(
 Assets::set_metadata(
     RuntimeOrigin::signed(admin),
     1,
-    b"Tokenised GBP".to_vec(),
+    b"tGBP".to_vec(),
     b"tGBP".to_vec(),
     18, // Same as Ethereum (no conversion)
 )?;
@@ -280,7 +280,7 @@ let tgbp_registration = AssetRegistration {
 
     reg: GatewayAssetRegistration {
         symbol: "tGBP".as_bytes().to_vec(),
-        name: "Tokenised GBP".as_bytes().to_vec(),
+        name: "tGBP".as_bytes().to_vec(),
         chains: vec![StateMachine::Evm(1)], // Ethereum mainnet
         minimum_balance: 1,
     },

--- a/docs/hyperbridge-integration/reference/EXAMPLES.md
+++ b/docs/hyperbridge-integration/reference/EXAMPLES.md
@@ -54,7 +54,7 @@ Assets::create(
 Assets::set_metadata(
     RuntimeOrigin::signed(admin()),
     1,
-    b"Tokenised GBP".to_vec(),
+    b"tGBP".to_vec(),
     b"tGBP".to_vec(),
     18,  // Same decimals as Ethereum
 )?;
@@ -70,7 +70,7 @@ let tgbp_registration = AssetRegistration {
 
     reg: GatewayAssetRegistration {
         symbol: "tGBP".as_bytes().to_vec(),
-        name: "Tokenised GBP".as_bytes().to_vec(),
+        name: "tGBP".as_bytes().to_vec(),
         chains: vec![StateMachine::Evm(1)],  // Ethereum mainnet
         minimum_balance: Some(1),
     },

--- a/integration-tests/src/tests/tgbp_integration_tests.rs
+++ b/integration-tests/src/tests/tgbp_integration_tests.rs
@@ -48,7 +48,7 @@ fn register_tgbp_asset() {
     assert_ok!(Assets::force_set_metadata(
         RuntimeOrigin::root(),
         TGBP_LOCAL_ASSET_ID.into(),
-        b"Tokenised GBP".to_vec(),
+        b"tGBP".to_vec(),
         b"tGBP".to_vec(),
         18,    // 18 decimals (same as on Ethereum)
         false  // is_frozen
@@ -634,7 +634,7 @@ fn invalid_precision_mapping() {
 ///
 /// **Verification Points:**
 /// - Symbol: Should be "tGBP"
-/// - Name: Should be "Tokenised GBP" (or similar)
+/// - Name: Should be "tGBP" (or similar)
 /// - Decimals: Should be 18 (matching Ethereum precision)
 ///
 /// **Why it's important:**
@@ -677,7 +677,7 @@ fn asset_metadata_after_creation() {
             // Symbol should be "tGBP"
             assert!(!symbol.is_empty(), "Symbol should be set");
 
-            // Name should be something like "Tokenised GBP"
+            // Name should be something like "tGBP"
             assert!(!name.is_empty(), "Name should be set");
 
             // Decimals should be 18 (maintains native precision)

--- a/runtime/src/migrations/reserved_assets.rs
+++ b/runtime/src/migrations/reserved_assets.rs
@@ -116,7 +116,7 @@ impl OnRuntimeUpgrade for CreateReservedAssets {
 
         // Create Asset 1: tGBP
         if !pallet_assets::Asset::<Runtime, Instance2>::contains_key(TGBP_ASSET_ID) {
-            create_asset(TGBP_ASSET_ID, &sudo_key, TGBP_MIN_BALANCE, b"Tokenised GBP", b"tGBP", 18);
+            create_asset(TGBP_ASSET_ID, &sudo_key, TGBP_MIN_BALANCE, b"tGBP", b"tGBP", 18);
             writes += 2; // Asset + Metadata
             log::info!(
                 target: LOG_TARGET,


### PR DESCRIPTION
The changes in this PR substitute occurrences of `Tokenised GBP` with `tGBP`, such the information living in Xcavate is cohesive with the state in the deployed contracts of the `tGBP` token.

tGBP on mainnet: https://etherscan.io/token/0x27f6c8289550fCE67f6B50BeD1F519966aFE5287

tGBP on testnet: https://sepolia.etherscan.io/token/0xf6ef9adb61a48e29e36bc873070a46a3d2667ff3