### PR TITLE
Enhance event payloads and metadata handling in bucket pallet

### DIFF
--- a/pallets/pallet-bucket/src/functions.rs
+++ b/pallets/pallet-bucket/src/functions.rs
@@ -90,7 +90,7 @@ impl<T: Config> Pallet<T> {
         }
 
         // insert namespace in storage
-        Namespaces::<T>::insert(&namespace_id, metadata);
+        Namespaces::<T>::insert(&namespace_id, metadata.clone());
 
         if let Some(ref manager) = caller {
             // insert manager in storage
@@ -101,7 +101,7 @@ impl<T: Config> Pallet<T> {
             .checked_add(&T::NamespaceId::one())
             .ok_or(Error::<T>::ArithmeticOverflow)?;
         NextNamespaceId::<T>::put(next_namespace_id);
-        Self::deposit_event(Event::NamespaceCreated { namespace_id, creator: caller });
+        Self::deposit_event(Event::NamespaceCreated { namespace_id, metadata, creator: caller });
 
         Ok(())
     }
@@ -117,9 +117,9 @@ impl<T: Config> Pallet<T> {
         ensure!(!Managers::<T>::contains_prefix(&namespace_id), Error::<T>::DanglingManagers);
 
         // find and remove namespace
-        Namespaces::<T>::take(&namespace_id).ok_or(Error::<T>::UnknownNamespace)?;
+        let metadata = Namespaces::<T>::take(&namespace_id).ok_or(Error::<T>::UnknownNamespace)?;
 
-        Self::deposit_event(Event::NamespaceDeleted { namespace_id });
+        Self::deposit_event(Event::NamespaceDeleted { namespace_id, metadata });
 
         Ok(())
     }
@@ -157,7 +157,7 @@ impl<T: Config> Pallet<T> {
         let bucket: BucketDetailsOf<T> = Bucket::new(metadata);
 
         // insert bucket in storage
-        Buckets::<T>::insert(&namespace_id, &bucket_id, bucket);
+        Buckets::<T>::insert(&namespace_id, &bucket_id, bucket.clone());
 
         // increment next bucket id
         let next_bucket_id = bucket_id.checked_add(&One::one()).ok_or(ArithmeticError::Overflow)?;
@@ -167,6 +167,7 @@ impl<T: Config> Pallet<T> {
         Self::deposit_event(Event::BucketCreated {
             namespace_id,
             bucket_id: bucket_id.clone(),
+            bucket,
             creator: caller,
         });
 
@@ -189,9 +190,9 @@ impl<T: Config> Pallet<T> {
         ensure!(!Tags::<T>::contains_prefix(&bucket_id), Error::<T>::DanglingTags);
 
         // find and remove bucket
-        Buckets::<T>::take(&namespace_id, &bucket_id).ok_or(Error::<T>::UnknownBucket)?;
+        let bucket = Buckets::<T>::take(&namespace_id, &bucket_id).ok_or(Error::<T>::UnknownBucket)?;
 
-        Self::deposit_event(Event::BucketDeleted { namespace_id, bucket_id });
+        Self::deposit_event(Event::BucketDeleted { namespace_id, bucket_id, bucket });
 
         Ok(())
     }
@@ -270,7 +271,7 @@ impl<T: Config> Pallet<T> {
         // drop manager from set
         Managers::<T>::remove(&namespace_id, &manager);
 
-        Self::deposit_event(Event::ManagerRemoved { namespace_id, manager });
+        Self::deposit_event(Event::ManagerRemoved { namespace_id, manager, caller });
 
         Ok(())
     }
@@ -297,7 +298,12 @@ impl<T: Config> Pallet<T> {
         // insert admin in storage
         Admins::<T>::insert(&bucket_id, &new_admin, ());
 
-        Self::deposit_event(Event::AdminAdded { namespace_id, bucket_id, admin: new_admin });
+        Self::deposit_event(Event::AdminAdded {
+            namespace_id,
+            bucket_id,
+            admin: new_admin,
+            caller,
+        });
 
         Ok(())
     }
@@ -325,7 +331,7 @@ impl<T: Config> Pallet<T> {
         // remove admin from storage
         Admins::<T>::remove(&bucket_id, &admin);
 
-        Self::deposit_event(Event::AdminRemoved { namespace_id, bucket_id, admin });
+        Self::deposit_event(Event::AdminRemoved { namespace_id, bucket_id, admin, caller });
 
         Ok(())
     }
@@ -353,7 +359,12 @@ impl<T: Config> Pallet<T> {
         // insert contributor in storage
         Contributors::<T>::insert(&bucket_id, &contributor, ());
 
-        Self::deposit_event(Event::ContributorAdded { namespace_id, bucket_id, contributor });
+        Self::deposit_event(Event::ContributorAdded {
+            namespace_id,
+            bucket_id,
+            contributor,
+            caller,
+        });
 
         Ok(())
     }
@@ -379,7 +390,12 @@ impl<T: Config> Pallet<T> {
         // drop contributor
         Contributors::<T>::remove(&bucket_id, &contributor);
 
-        Self::deposit_event(Event::ContributorRemoved { namespace_id, bucket_id, contributor });
+        Self::deposit_event(Event::ContributorRemoved {
+            namespace_id,
+            bucket_id,
+            contributor,
+            caller,
+        });
 
         Ok(())
     }
@@ -394,22 +410,26 @@ impl<T: Config> Pallet<T> {
         bucket_id: T::BucketId,
         caller: Option<SubjectIdOf<T>>,
     ) -> DispatchResult {
-        if let Some(admin) = caller {
+        if let Some(ref admin) = caller {
             // check if origin is an admin for the bucket
-            Self::ensure_is_admin(&bucket_id, &admin)?;
+            Self::ensure_is_admin(&bucket_id, admin)?;
         };
 
-        Buckets::<T>::try_mutate(&namespace_id, &bucket_id, |bucket| -> DispatchResult {
+        let bucket = Buckets::<T>::try_mutate(
+            &namespace_id,
+            &bucket_id,
+            |bucket| -> Result<BucketDetailsOf<T>, DispatchError> {
             let Some(bucket) = bucket else {
                 return Err(Error::<T>::UnknownBucket.into());
             };
 
             bucket.lock();
 
-            Ok(())
-        })?;
+            Ok(bucket.clone())
+        },
+        )?;
 
-        Self::deposit_event(Event::PausedBucket { namespace_id, bucket_id });
+        Self::deposit_event(Event::PausedBucket { namespace_id, bucket_id, bucket, caller });
 
         Ok(())
     }
@@ -428,12 +448,15 @@ impl<T: Config> Pallet<T> {
         allow_locked: bool,
         caller: Option<SubjectIdOf<T>>,
     ) -> DispatchResult {
-        if let Some(admin) = caller {
+        if let Some(ref admin) = caller {
             // check if origin is an admin for the bucket
-            Self::ensure_is_admin(&bucket_id, &admin)?;
+            Self::ensure_is_admin(&bucket_id, admin)?;
         };
 
-        Buckets::<T>::try_mutate(&namespace_id, &bucket_id, |bucket| -> DispatchResult {
+        let bucket = Buckets::<T>::try_mutate(
+            &namespace_id,
+            &bucket_id,
+            |bucket| -> Result<BucketDetailsOf<T>, DispatchError> {
             let Some(bucket) = bucket else {
                 return Err(Error::<T>::UnknownBucket.into());
             };
@@ -442,13 +465,16 @@ impl<T: Config> Pallet<T> {
 
             bucket.set_writable(new_encryption_key.clone());
 
-            Ok(())
-        })?;
+            Ok(bucket.clone())
+        },
+        )?;
 
         Self::deposit_event(Event::BucketWritableWithKey {
             namespace_id,
             bucket_id,
             new_encryption_key,
+            bucket,
+            caller,
         });
 
         Ok(())
@@ -466,9 +492,9 @@ impl<T: Config> Pallet<T> {
         caller: Option<SubjectIdOf<T>>,
         payer: Option<AccountIdOf<T>>,
     ) -> DispatchResult {
-        if let Some(admin) = caller {
+        if let Some(ref admin) = caller {
             // check if origin is an admin for the bucket
-            Self::ensure_is_admin(&bucket_id, &admin)?;
+            Self::ensure_is_admin(&bucket_id, admin)?;
         };
 
         // take fees from the payer
@@ -480,7 +506,7 @@ impl<T: Config> Pallet<T> {
         // insert tag in storage
         Tags::<T>::insert(&bucket_id, &tag, ());
 
-        Self::deposit_event(Event::NewTag { bucket_id, tag });
+        Self::deposit_event(Event::NewTag { bucket_id, tag, creator: caller });
 
         Ok(())
     }
@@ -534,8 +560,10 @@ impl<T: Config> Pallet<T> {
         Buckets::<T>::insert(&namespace_id, &bucket_id, bucket);
 
         Self::deposit_event(Event::NewMessage {
+            namespace_id,
             bucket_id,
             message_id: message_id.clone(),
+            message: message_details,
             contributor,
         });
 
@@ -563,7 +591,7 @@ impl<T: Config> Pallet<T> {
             })?;
         }
 
-        Self::deposit_event(Event::MessageDeleted { bucket_id, message_id });
+        Self::deposit_event(Event::MessageDeleted { bucket_id, message_id, message: message_details });
 
         Ok(())
     }

--- a/pallets/pallet-bucket/src/functions.rs
+++ b/pallets/pallet-bucket/src/functions.rs
@@ -419,7 +419,7 @@ impl<T: Config> Pallet<T> {
             &namespace_id,
             &bucket_id,
             |bucket| -> Result<BucketDetailsOf<T>, DispatchError> {
-            let Some(bucket) = bucket else {
+            let Some(bucket) = bucket.as_mut() else {
                 return Err(Error::<T>::UnknownBucket.into());
             };
 
@@ -457,9 +457,7 @@ impl<T: Config> Pallet<T> {
             &namespace_id,
             &bucket_id,
             |bucket| -> Result<BucketDetailsOf<T>, DispatchError> {
-            let Some(bucket) = bucket else {
-                return Err(Error::<T>::UnknownBucket.into());
-            };
+            let bucket = bucket.as_mut().ok_or(Error::<T>::UnknownBucket)?;
 
             ensure!(allow_locked || bucket.is_writable(), Error::<T>::BucketIsLocked);
 

--- a/pallets/pallet-bucket/src/lib.rs
+++ b/pallets/pallet-bucket/src/lib.rs
@@ -334,13 +334,18 @@ pub mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// A new namespace has been created.
-        NamespaceCreated { namespace_id: T::NamespaceId, creator: Option<SubjectIdOf<T>> },
+        NamespaceCreated {
+            namespace_id: T::NamespaceId,
+            metadata: T::NamespaceMetadata,
+            creator: Option<SubjectIdOf<T>>,
+        },
 
         /// A contributor is assigned to a bucket.
         ContributorAdded {
             namespace_id: T::NamespaceId,
             bucket_id: T::BucketId,
             contributor: SubjectIdOf<T>,
+            caller: Option<SubjectIdOf<T>>,
         },
 
         /// A contributor is removed from a bucket.
@@ -348,13 +353,24 @@ pub mod pallet {
             namespace_id: T::NamespaceId,
             bucket_id: T::BucketId,
             contributor: SubjectIdOf<T>,
+            caller: Option<SubjectIdOf<T>>,
         },
 
         /// A new admin is assigned to a bucket.
-        AdminAdded { namespace_id: T::NamespaceId, bucket_id: T::BucketId, admin: SubjectIdOf<T> },
+        AdminAdded {
+            namespace_id: T::NamespaceId,
+            bucket_id: T::BucketId,
+            admin: SubjectIdOf<T>,
+            caller: Option<SubjectIdOf<T>>,
+        },
 
         /// An admin is removed from a bucket.
-        AdminRemoved { namespace_id: T::NamespaceId, bucket_id: T::BucketId, admin: SubjectIdOf<T> },
+        AdminRemoved {
+            namespace_id: T::NamespaceId,
+            bucket_id: T::BucketId,
+            admin: SubjectIdOf<T>,
+            caller: Option<SubjectIdOf<T>>,
+        },
 
         /// A new manager is assigned to an namespace.
         ManagerAdded {
@@ -364,17 +380,27 @@ pub mod pallet {
         },
 
         /// A manager is removed from an namespace.
-        ManagerRemoved { namespace_id: T::NamespaceId, manager: SubjectIdOf<T> },
+        ManagerRemoved {
+            namespace_id: T::NamespaceId,
+            manager: SubjectIdOf<T>,
+            caller: Option<SubjectIdOf<T>>,
+        },
 
         /// A new bucket has been created.
         BucketCreated {
             namespace_id: T::NamespaceId,
             bucket_id: T::BucketId,
+            bucket: BucketDetailsOf<T>,
             creator: Option<SubjectIdOf<T>>,
         },
 
         /// A bucket has been paused for writing.
-        PausedBucket { namespace_id: T::NamespaceId, bucket_id: T::BucketId },
+        PausedBucket {
+            namespace_id: T::NamespaceId,
+            bucket_id: T::BucketId,
+            bucket: BucketDetailsOf<T>,
+            caller: Option<SubjectIdOf<T>>,
+        },
 
         /// A bucket is writable with a specific key.
         /// This event is independent of the bucket being previously paused or not.
@@ -382,25 +408,41 @@ pub mod pallet {
             namespace_id: T::NamespaceId,
             bucket_id: T::BucketId,
             new_encryption_key: KeyIdOf<T>,
+            bucket: BucketDetailsOf<T>,
+            caller: Option<SubjectIdOf<T>>,
         },
 
         /// A new tag has been created.
-        NewTag { bucket_id: T::BucketId, tag: TagOf<T> },
+        NewTag { bucket_id: T::BucketId, tag: TagOf<T>, creator: Option<SubjectIdOf<T>> },
 
         /// A new message has been written.
-        NewMessage { bucket_id: T::BucketId, message_id: T::MessageId, contributor: SubjectIdOf<T> },
+        NewMessage {
+            namespace_id: T::NamespaceId,
+            bucket_id: T::BucketId,
+            message_id: T::MessageId,
+            message: MessageDetailsOf<T>,
+            contributor: SubjectIdOf<T>,
+        },
 
         /// An namespace has been deleted.
-        NamespaceDeleted { namespace_id: T::NamespaceId },
+        NamespaceDeleted { namespace_id: T::NamespaceId, metadata: T::NamespaceMetadata },
 
         /// A bucket has been deleted.
-        BucketDeleted { namespace_id: T::NamespaceId, bucket_id: T::BucketId },
+        BucketDeleted {
+            namespace_id: T::NamespaceId,
+            bucket_id: T::BucketId,
+            bucket: BucketDetailsOf<T>,
+        },
 
         /// A tag has been deleted.
         TagDeleted { bucket_id: T::BucketId, tag: TagOf<T> },
 
         /// A message has been deleted.
-        MessageDeleted { bucket_id: T::BucketId, message_id: T::MessageId },
+        MessageDeleted {
+            bucket_id: T::BucketId,
+            message_id: T::MessageId,
+            message: MessageDetailsOf<T>,
+        },
     }
 
     #[pallet::error]

--- a/pallets/pallet-bucket/src/tests/admins.rs
+++ b/pallets/pallet-bucket/src/tests/admins.rs
@@ -21,7 +21,8 @@ fn add_admin_through_manager() {
             assert!(events().contains(&crate::Event::AdminAdded {
                 namespace_id: DEFAULT_NAMESPACE_ID,
                 bucket_id: DEFAULT_BUCKET_ID,
-                admin: ACCOUNT_01
+                admin: ACCOUNT_01,
+                caller: Some(ACCOUNT_00)
             }));
             assert_eq!(events().len(), 1);
         });
@@ -132,7 +133,8 @@ fn remove_admin() {
             assert!(events().contains(&crate::Event::AdminRemoved {
                 namespace_id: DEFAULT_NAMESPACE_ID,
                 bucket_id: DEFAULT_BUCKET_ID,
-                admin: ACCOUNT_01
+                admin: ACCOUNT_01,
+                caller: Some(ACCOUNT_00)
             }));
             assert_eq!(events().len(), 1);
         });

--- a/pallets/pallet-bucket/src/tests/buckets.rs
+++ b/pallets/pallet-bucket/src/tests/buckets.rs
@@ -1,6 +1,7 @@
 use frame_support::{assert_err, assert_noop, assert_ok, sp_runtime::DispatchError};
 use frame_system::RawOrigin;
 
+use crate::types::Status;
 use crate::{mock::*, Error};
 
 #[test]
@@ -31,6 +32,11 @@ fn create_bucket() {
             assert!(events().contains(&crate::Event::BucketCreated {
                 namespace_id: DEFAULT_NAMESPACE_ID,
                 bucket_id: 0,
+                bucket: BucketMock {
+                    metadata: MetadataMock { unique_plus_1: 21 },
+                    status: Status::Locked,
+                    next_message_id: 0,
+                },
                 creator: Some(ACCOUNT_00)
             }));
             assert_eq!(events().len(), 1);
@@ -114,6 +120,7 @@ fn remove_bucket() {
             assert!(events().contains(&crate::Event::BucketDeleted {
                 namespace_id: DEFAULT_NAMESPACE_ID,
                 bucket_id: DEFAULT_BUCKET_ID,
+                bucket: BUCKET_EXAMPLE_LOCKED,
             }));
             assert_eq!(events().len(), 1);
         });

--- a/pallets/pallet-bucket/src/tests/contributors.rs
+++ b/pallets/pallet-bucket/src/tests/contributors.rs
@@ -22,7 +22,8 @@ fn add_contributor() {
             assert!(events().contains(&crate::Event::ContributorAdded {
                 namespace_id: DEFAULT_NAMESPACE_ID,
                 bucket_id: DEFAULT_BUCKET_ID,
-                contributor: ACCOUNT_01
+                contributor: ACCOUNT_01,
+                caller: Some(ACCOUNT_00)
             }));
             assert_eq!(events().len(), 1);
         });
@@ -91,7 +92,8 @@ fn remove_contributor() {
             assert!(events().contains(&crate::Event::ContributorRemoved {
                 namespace_id: DEFAULT_NAMESPACE_ID,
                 bucket_id: DEFAULT_BUCKET_ID,
-                contributor: ACCOUNT_01
+                contributor: ACCOUNT_01,
+                caller: Some(ACCOUNT_00)
             }));
             assert_eq!(events().len(), 1);
         });

--- a/pallets/pallet-bucket/src/tests/managers.rs
+++ b/pallets/pallet-bucket/src/tests/managers.rs
@@ -77,6 +77,7 @@ fn remove_manager() {
             assert!(events().contains(&crate::Event::ManagerRemoved {
                 namespace_id: DEFAULT_NAMESPACE_ID,
                 manager: ACCOUNT_00,
+                caller: Some(ACCOUNT_00),
             }));
             assert_eq!(events().len(), 1);
         });

--- a/pallets/pallet-bucket/src/tests/namespaces.rs
+++ b/pallets/pallet-bucket/src/tests/namespaces.rs
@@ -23,6 +23,7 @@ fn create_namespace() {
             let events = events();
             assert!(events.contains(&crate::Event::NamespaceCreated {
                 namespace_id: DEFAULT_NAMESPACE_ID,
+                metadata: MetadataMock { unique_plus_1: 11 },
                 creator: Some(ACCOUNT_00),
             }));
             assert!(events.contains(&crate::Event::ManagerAdded {
@@ -133,8 +134,10 @@ fn force_remove_namespace() {
         assert!(Buckets::namespace_with_id(DEFAULT_NAMESPACE_ID).is_some());
         assert_ok!(Buckets::force_remove_namespace(origin.into(), DEFAULT_NAMESPACE_ID),);
         assert!(Buckets::namespace_with_id(DEFAULT_NAMESPACE_ID).is_none());
-        assert!(events()
-            .contains(&crate::Event::NamespaceDeleted { namespace_id: DEFAULT_NAMESPACE_ID }));
+        assert!(events().contains(&crate::Event::NamespaceDeleted {
+            namespace_id: DEFAULT_NAMESPACE_ID,
+            metadata: MetadataMock { unique_plus_1: 10 }
+        }));
         assert_eq!(events().len(), 1);
     })
 }

--- a/pallets/pallet-bucket/src/tests/pause_writing.rs
+++ b/pallets/pallet-bucket/src/tests/pause_writing.rs
@@ -22,7 +22,13 @@ fn pause_writing() {
 
             assert!(events().contains(&crate::Event::PausedBucket {
                 namespace_id: DEFAULT_NAMESPACE_ID,
-                bucket_id: DEFAULT_BUCKET_ID
+                bucket_id: DEFAULT_BUCKET_ID,
+                bucket: BucketMock {
+                    metadata: MetadataMock { unique_plus_1: 10 },
+                    status: Status::Locked,
+                    next_message_id: 2,
+                },
+                caller: Some(ACCOUNT_00)
             }));
             assert_eq!(events().len(), 1);
         });

--- a/pallets/pallet-bucket/src/tests/resume_writing.rs
+++ b/pallets/pallet-bucket/src/tests/resume_writing.rs
@@ -24,7 +24,13 @@ fn resume_writing() {
             assert!(events().contains(&crate::Event::BucketWritableWithKey {
                 namespace_id: DEFAULT_NAMESPACE_ID,
                 bucket_id: DEFAULT_BUCKET_ID,
-                new_encryption_key: DEFAULT_ENCRYPTION_KEY
+                new_encryption_key: DEFAULT_ENCRYPTION_KEY,
+                bucket: BucketMock {
+                    metadata: MetadataMock { unique_plus_1: 10 },
+                    status: Status::Writable(DEFAULT_ENCRYPTION_KEY),
+                    next_message_id: 2,
+                },
+                caller: Some(ACCOUNT_00)
             }));
             assert_eq!(events().len(), 1);
         });

--- a/pallets/pallet-bucket/src/tests/rotate_key.rs
+++ b/pallets/pallet-bucket/src/tests/rotate_key.rs
@@ -25,7 +25,13 @@ fn rotate_key() {
             assert!(events().contains(&crate::Event::BucketWritableWithKey {
                 namespace_id: DEFAULT_NAMESPACE_ID,
                 bucket_id: DEFAULT_BUCKET_ID,
-                new_encryption_key: DEFAULT_ENCRYPTION_KEY
+                new_encryption_key: DEFAULT_ENCRYPTION_KEY,
+                bucket: BucketMock {
+                    metadata: MetadataMock { unique_plus_1: 10 },
+                    status: Status::Writable(DEFAULT_ENCRYPTION_KEY),
+                    next_message_id: 2,
+                },
+                caller: Some(ACCOUNT_00)
             }));
         });
 }

--- a/pallets/pallet-bucket/src/tests/tags.rs
+++ b/pallets/pallet-bucket/src/tests/tags.rs
@@ -16,7 +16,11 @@ fn create_tag() {
             assert_ok!(Buckets::create_tag(origin.into(), DEFAULT_BUCKET_ID, tag.clone()));
             assert!(Buckets::tag_with_id(DEFAULT_BUCKET_ID, tag.clone()).is_some());
 
-            assert!(events().contains(&crate::Event::NewTag { bucket_id: DEFAULT_BUCKET_ID, tag }));
+            assert!(events().contains(&crate::Event::NewTag {
+                bucket_id: DEFAULT_BUCKET_ID,
+                tag,
+                creator: Some(ACCOUNT_01)
+            }));
             assert_eq!(events().len(), 1);
         });
 }

--- a/pallets/pallet-bucket/src/tests/write.rs
+++ b/pallets/pallet-bucket/src/tests/write.rs
@@ -33,9 +33,15 @@ fn write_without_tag() {
             assert!(Buckets::message_with_id(DEFAULT_BUCKET_ID, message_id).is_some());
 
             assert!(events().contains(&crate::Event::NewMessage {
+                namespace_id: DEFAULT_NAMESPACE_ID,
                 bucket_id: DEFAULT_BUCKET_ID,
                 contributor: ACCOUNT_01,
-                message_id
+                message_id,
+                message: MessageMock {
+                    reference: create_bounded_vec_example(0),
+                    tag: None,
+                    metadata: MetadataMock { unique_plus_1: 13 },
+                }
             }));
             assert_eq!(events().len(), 1);
         });
@@ -158,7 +164,7 @@ fn force_remove_message() {
         .add_namespace(DEFAULT_NAMESPACE_ID, MetadataMock { unique_plus_1: 10 })
         .add_bucket(DEFAULT_NAMESPACE_ID, DEFAULT_BUCKET_ID, BUCKET_EXAMPLE_LOCKED)
         .add_contributor(DEFAULT_BUCKET_ID, ACCOUNT_01)
-        .add_message(DEFAULT_BUCKET_ID, MESSAGE_ID, message)
+        .add_message(DEFAULT_BUCKET_ID, MESSAGE_ID, message.clone())
         .build_and_execute_with_sanity_tests(|| {
             assert!(Messages::<Test>::get(DEFAULT_BUCKET_ID, MESSAGE_ID).is_some());
             let origin = RawOrigin::Root;
@@ -167,7 +173,8 @@ fn force_remove_message() {
             assert!(Messages::<Test>::get(DEFAULT_BUCKET_ID, MESSAGE_ID).is_none());
             assert!(events().contains(&crate::Event::MessageDeleted {
                 bucket_id: DEFAULT_BUCKET_ID,
-                message_id: MESSAGE_ID
+                message_id: MESSAGE_ID,
+                message,
             }));
         });
 }

--- a/pallets/pallet-bucket/src/types.rs
+++ b/pallets/pallet-bucket/src/types.rs
@@ -196,7 +196,18 @@ impl<T: Config> From<MessageMetadataInput<T>> for MessageMetadata<T> {
     }
 }
 
-#[derive(Clone, Decode, RuntimeDebug, Encode, TypeInfo, MaxEncodedLen, Default)]
+#[derive(
+    Clone,
+    Decode,
+    DecodeWithMemTracking,
+    RuntimeDebug,
+    Encode,
+    TypeInfo,
+    MaxEncodedLen,
+    PartialEq,
+    Eq,
+    Default,
+)]
 pub enum Status<KeyId> {
     /// Bucket is writable. Admin can lock it.
     Writable(KeyId),
@@ -205,7 +216,17 @@ pub enum Status<KeyId> {
     Locked,
 }
 
-#[derive(Clone, Decode, RuntimeDebug, Encode, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Decode,
+    DecodeWithMemTracking,
+    RuntimeDebug,
+    Encode,
+    TypeInfo,
+    MaxEncodedLen,
+    PartialEq,
+    Eq,
+)]
 pub struct Bucket<Metadata, MessageId, KeyId> {
     /// Metadata of the bucket.
     pub metadata: Metadata,
@@ -262,7 +283,17 @@ pub struct MessageInput<Tag, Reference, Metadata> {
     pub(crate) metadata_input: Metadata,
 }
 
-#[derive(Clone, Decode, RuntimeDebug, Encode, TypeInfo, MaxEncodedLen)]
+#[derive(
+    Clone,
+    Decode,
+    DecodeWithMemTracking,
+    RuntimeDebug,
+    Encode,
+    TypeInfo,
+    MaxEncodedLen,
+    PartialEq,
+    Eq,
+)]
 pub struct Message<Reference, Tag, Metadata> {
     /// Unique reference of the message to the storage layer
     pub reference: Reference,


### PR DESCRIPTION
I encountered an issue that there are not all of the important information exposed in the events that would allow us build an indexer.

This PR add all important information to the events so that it can be exposed and indexed without complicated (and sub-optimal) workarounds.