### PR TITLE
Bucket namespace creation for properties

### DIFF
--- a/pallets/marketplace/src/mock.rs
+++ b/pallets/marketplace/src/mock.rs
@@ -370,6 +370,7 @@ impl pallet_real_world_asset::Config for Test {
     type StringLimit = ConstU32<50>;
     type RegionProvider = Regions;
     type PostcodeLimit = Postcode;
+    type NamespaceManager = ();
 }
 
 // Mock IncomeSettlement implementation

--- a/pallets/property-governance/src/mock.rs
+++ b/pallets/property-governance/src/mock.rs
@@ -370,6 +370,7 @@ impl pallet_real_world_asset::Config for Test {
     type StringLimit = ConstU32<50>;
     type RegionProvider = Regions;
     type PostcodeLimit = Postcode;
+    type NamespaceManager = ();
 }
 
 parameter_types! {

--- a/pallets/property-management/src/mock.rs
+++ b/pallets/property-management/src/mock.rs
@@ -369,6 +369,7 @@ impl pallet_real_world_asset::Config for Test {
     type StringLimit = ConstU32<50>;
     type RegionProvider = Regions;
     type PostcodeLimit = Postcode;
+    type NamespaceManager = ();
 }
 
 parameter_types! {

--- a/pallets/real-world-asset/src/lib.rs
+++ b/pallets/real-world-asset/src/lib.rs
@@ -53,6 +53,22 @@ pub type LocalAssetIdOf<T> = <<T as Config>::LocalCurrency as fungibles::Inspect
     <T as frame_system::Config>::AccountId,
 >>::AssetId;
 
+pub trait NamespaceManager<AccountId> {
+    fn create_namespace_for_property(
+        manager: &AccountId,
+        real_world_asset_id: u32,
+    ) -> Result<u128, DispatchError>;
+}
+
+impl<AccountId> NamespaceManager<AccountId> for () {
+    fn create_namespace_for_property(
+        _manager: &AccountId,
+        _real_world_asset_id: u32,
+    ) -> Result<u128, DispatchError> {
+        Ok(0)
+    }
+}
+
 #[frame_support::pallet]
 pub mod pallet {
     use super::*;
@@ -69,6 +85,8 @@ pub mod pallet {
         pub collection_id: NftCollectionId,
         /// The NFT item ID for the property.
         pub item_id: NftId,
+        /// The namespace ID used for bucket-backed property data.
+        pub namespace_id: u128,
         /// The region ID where the property is located.
         pub region: RegionId,
         /// The location ID within the region.
@@ -182,6 +200,9 @@ pub mod pallet {
         /// The maximum length of data stored in for post codes.
         #[pallet::constant]
         type PostcodeLimit: Get<u32>;
+
+        /// Namespace manager used to create and assign namespaces for property assets.
+        type NamespaceManager: super::NamespaceManager<AccountIdOf<Self>>;
     }
 
     pub type FractionalizedAssetId<T> = <T as Config>::AssetId;
@@ -245,7 +266,7 @@ pub mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// Test
-        PropertyTokenCreated { asset_id: u32 },
+        PropertyTokenCreated { asset_id: u32, namespace_id: u128 },
         /// The property nft got burned.
         PropertyNftBurned {
             collection_id: <T as pallet::Config>::NftCollectionId,
@@ -358,12 +379,16 @@ pub mod pallet {
                 token_amount.into(),
             )?;
 
+            let namespace_id =
+                T::NamespaceManager::create_namespace_for_property(funding_account, asset_number)?;
+
             // Store asset details
             PropertyAssetInfo::<T>::insert(
                 asset_number,
                 PropertyAssetDetails {
                     collection_id: region_info.collection_id,
                     item_id,
+                    namespace_id,
                     region,
                     location,
                     price: property_price,
@@ -380,7 +405,10 @@ pub mod pallet {
 
             NextNftId::<T>::insert(region_info.collection_id, next_item_id);
             NextAssetId::<T>::put(next_asset_number);
-            Self::deposit_event(Event::<T>::PropertyTokenCreated { asset_id: asset_number });
+            Self::deposit_event(Event::<T>::PropertyTokenCreated {
+                asset_id: asset_number,
+                namespace_id,
+            });
             Ok((item_id, asset_number))
         }
 

--- a/pallets/real-world-asset/src/lib.rs
+++ b/pallets/real-world-asset/src/lib.rs
@@ -27,6 +27,7 @@ mod tests;
 pub mod traits;
 
 use frame_support::pallet_prelude::*;
+use frame_support::transactional;
 
 use frame_support::sp_runtime::traits::{AccountIdConversion, StaticLookup};
 use frame_support::{
@@ -315,6 +316,7 @@ pub mod pallet {
 
         /// Create a new property token by minting an NFT and fractionalizing it into tokens.   
         /// Transfers funding to the property account, mints an NFT, fractionalizes it, and stores details.
+        #[transactional]
         pub(crate) fn do_create_property_token(
             funding_account: &AccountIdOf<T>,
             region: RegionId,

--- a/pallets/real-world-asset/src/mock.rs
+++ b/pallets/real-world-asset/src/mock.rs
@@ -323,6 +323,7 @@ impl crate::Config for Test {
     type StringLimit = ConstU32<50>;
     type RegionProvider = Regions;
     type PostcodeLimit = Postcode;
+    type NamespaceManager = ();
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/real-world-asset/src/tests.rs
+++ b/pallets/real-world-asset/src/tests.rs
@@ -108,6 +108,7 @@ fn create_property_token_works() {
             PropertyAssetDetails {
                 collection_id: 0,
                 item_id: 0,
+                namespace_id: 0,
                 region: 3,
                 location: bvec![10, 10],
                 price: 1_000,
@@ -414,6 +415,7 @@ fn register_spv_works() {
             PropertyAssetDetails {
                 collection_id: 0,
                 item_id: 0,
+                namespace_id: 0,
                 region: 3,
                 location: bvec![10, 10],
                 price: 1_000,
@@ -428,6 +430,7 @@ fn register_spv_works() {
             PropertyAssetDetails {
                 collection_id: 0,
                 item_id: 0,
+                namespace_id: 0,
                 region: 3,
                 location: bvec![10, 10],
                 price: 1_000,
@@ -468,6 +471,7 @@ fn getter_function_works() {
             PropertyAssetDetails {
                 collection_id: 0,
                 item_id: 0,
+                namespace_id: 0,
                 region: 3,
                 location: bvec![10, 10],
                 price: 1_000,

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -919,6 +919,42 @@ parameter_types! {
     pub const MaxPropertyTokens: u32 = 250;
 }
 
+pub struct BucketNamespaceManager;
+
+impl pallet_real_world_asset::NamespaceManager<AccountId> for BucketNamespaceManager {
+    fn create_namespace_for_property(
+        manager: &AccountId,
+        real_world_asset_id: u32,
+    ) -> Result<u128, frame_support::pallet_prelude::DispatchError> {
+        let mut properties =
+            frame_support::storage::bounded_btree_map::BoundedBTreeMap::default();
+        properties
+            .try_insert(
+                BoundedVec::truncate_from(b"propertyId".to_vec()),
+                BoundedVec::truncate_from(real_world_asset_id.to_le_bytes().to_vec()),
+            )
+            .map_err(|_| {
+                frame_support::pallet_prelude::DispatchError::Other(
+                    "Namespace metadata properties full",
+                )
+            })?;
+
+        let namespace_id = pallet_bucket::NextNamespaceId::<Runtime>::get();
+        let metadata_input = pallet_bucket::types::NamespaceMetadataInput::<Runtime> {
+            name: BoundedVec::truncate_from(b"Property namespace".to_vec()),
+            schema_uri: None,
+            properties,
+        };
+
+        <pallet_bucket::Pallet<Runtime> as pallet_bucket::traits::Create<Runtime>>::namespace(
+            metadata_input.into(),
+            Some(manager.clone()),
+        )?;
+
+        Ok(namespace_id)
+    }
+}
+
 /// Configure the pallet-property-governance in pallets/property-governance.
 impl pallet_real_world_asset::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
@@ -937,6 +973,7 @@ impl pallet_real_world_asset::Config for Runtime {
     type StringLimit = StringLimit;
     type RegionProvider = Regions;
     type PostcodeLimit = Postcode;
+    type NamespaceManager = BucketNamespaceManager;
 }
 
 parameter_types! {


### PR DESCRIPTION
When a new property is registered on-chain, it also creates a new namespace (in buckets pallet) associated with the property.

RealEstateDeveloper becomes the manager of the newly created namespace